### PR TITLE
chore: USE RPC URL ALIASES IN `foundry.toml`, INSTEAD OF THE ACTUAL URLS.

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -2,7 +2,7 @@
 src = "src"
 out = "out"
 libs = ["lib"]
-rpc_endpoints = { eth = "https://eth-sepolia.g.alchemy.com/v2/mwHkM74gwkO6kdWQKCYBRWdbDUnhZB7E", arb = "https://arb-sepolia.g.alchemy.com/v2/mwHkM74gwkO6kdWQKCYBRWdbDUnhZB7E", zksync = "https://sepolia.era.zksync.dev"}
+rpc_endpoints = { eth = "${SEPOLIA_RPC_URL}", arb = "${ARBITRUM_SEPOLIA_RPC_URL}", zksync = "${ZKSYNC_SEPOLIA_RPC_URL}" }
 
 remappings = [
     '@openzeppelin/=lib/openzeppelin-contracts/',


### PR DESCRIPTION
 I stored the RPC URLs in the `.env` file and used the aliases in the `foundry.toml`, a safer and cleaner approach.
 
 Before:
```
rpc_endpoints = { eth = "https://eth-sepolia.g.alchemy.com/v2/mwHkM74gwkO6kdWQKCYBRWdbDUnhZB7E", arb = "https://arb-sepolia.g.alchemy.com/v2/mwHkM74gwkO6kdWQKCYBRWdbDUnhZB7E", zksync = "https://sepolia.era.zksync.dev"}

```
 After:
 ```
rpc_endpoints = { eth = "${SEPOLIA_RPC_URL}", arb = "${ARBITRUM_SEPOLIA_RPC_URL}", zksync = "${ZKSYNC_SEPOLIA_RPC_URL}" }
 ```