### PR TITLE
test: assert exact AccessControl revert for unauthorized mint and burn

### DIFF
--- a/test/RebaseToken.t.sol
+++ b/test/RebaseToken.t.sol
@@ -7,6 +7,7 @@ import {RebaseToken} from "../src/RebaseToken.sol";
 import {Vault} from "../src/Vault.sol";
 
 import {IRebaseToken} from "../src/interfaces/IRebaseToken.sol";
+import {IAccessControl} from "@openzeppelin/contracts/access/IAccessControl.sol";
 
 contract RebaseTokenTest is Test {
     RebaseToken public rebaseToken;
@@ -15,6 +16,7 @@ contract RebaseTokenTest is Test {
     address public user = makeAddr("user");
     address public owner = makeAddr("owner");
     uint256 public SEND_VALUE = 1e5;
+    bytes32 private constant MINT_AND_BURN_ROLE = keccak256("MINT_AND_BURN_ROLE");
 
     function addRewardsToVault(uint256 amount) public {
         // send some rewards to the vault using the receive function
@@ -109,7 +111,7 @@ contract RebaseTokenTest is Test {
         // Deposit funds
         vm.startPrank(user);
         uint256 interestRate = rebaseToken.getInterestRate();
-        vm.expectRevert();
+        vm.expectRevert(abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, user, MINT_AND_BURN_ROLE));
         rebaseToken.mint(user, SEND_VALUE, interestRate);
         vm.stopPrank();
     }
@@ -117,7 +119,7 @@ contract RebaseTokenTest is Test {
     function testCannotCallBurn() public {
         // Deposit funds
         vm.startPrank(user);
-        vm.expectRevert();
+        vm.expectRevert(abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, user, MINT_AND_BURN_ROLE));
         rebaseToken.burn(user, SEND_VALUE);
         vm.stopPrank();
     }


### PR DESCRIPTION
## Summary

This PR strengthens the access control tests in `test/RebaseToken.t.sol` by asserting the exact OpenZeppelin `AccessControlUnauthorizedAccount` custom error for unauthorized `mint` and `burn` calls.

## Changes

- imported `IAccessControl`
- added `MINT_AND_BURN_ROLE` constant in the test
- replaced generic `vm.expectRevert()` with exact revert assertions in:
  - `testCannotCallMint`
  - `testCannotCallBurn`

## Why

The contract protects `mint` and `burn` with role-based access control, so checking the exact revert reason makes the tests more precise and helps catch authorization regressions earlier.

Previously, the tests only checked that the calls reverted for some reason.
Now they verify that the revert happens for the intended access-control reason.

## Scope

Test-only change. No production contract logic changed.